### PR TITLE
Fix GitHub action release creation

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -26,7 +26,9 @@ jobs:
             ${{ runner.os }}-maven-
       - name: Deploy
         id: deploy
-        run: mvn -B clean deploy
+        run: |
+          mvn -B clean deploy
+          echo "::set-output name=version::$(mvn help:evaluate -Dexpression=project.version -q -DforceStdout)"
         env:
           MAVEN_USERNAME: jaredpetersen
           MAVEN_CENTRAL_TOKEN: ${{ secrets.MAVEN_CENTRAL_TOKEN }}


### PR DESCRIPTION
Fixed an issue where the Create Release step in the Release workflow referenced data that a previous step no longer outputted.