### PR TITLE
Source connector parallelization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [1.1.0] - 2020-12-10
+## [1.1.0] - 2020-12-11
 ### Added
 - Parallelization for source connector based on channels/patterns
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.0] - 2020-12-10
+### Added
+- Parallelization for source connector based on channels/patterns
+
+### Removed
+- Default configuration for Kafka topic
+
 ## [1.0.4] - 2020-11-29
 ### Added
 - Added support for sinking arbitrary Redis commands, primarily for use with Redis modules

--- a/docs/connectors/SINK.md
+++ b/docs/connectors/SINK.md
@@ -424,6 +424,9 @@ Keys are ignored.
 ```
 
 ## Configuration
+### Parallelization
+Splitting the workload between multiple tasks is possible via the configuration property `max.tasks`. The configured number will exactly determine the number of tasks that are created.
+
 ### Connector Properties
 | Name                    | Type    | Default | Importance | Description                                             |
 | ----------------------- | ------- | ------- | ---------- | ------------------------------------------------------- |

--- a/docs/connectors/SINK.md
+++ b/docs/connectors/SINK.md
@@ -425,7 +425,7 @@ Keys are ignored.
 
 ## Configuration
 ### Parallelization
-Splitting the workload between multiple tasks is possible via the configuration property `max.tasks`. The configured number will exactly determine the number of tasks that are created.
+Splitting the workload between multiple tasks is possible via the configuration property `tasks.max`. The configured number will exactly determine the number of tasks that are created.
 
 ### Connector Properties
 | Name                    | Type    | Default | Importance | Description                                             |

--- a/docs/connectors/SOURCE.md
+++ b/docs/connectors/SOURCE.md
@@ -82,7 +82,7 @@ In the case of subscribing to Redis keyspace notifications, it may be useful to 
 The plugin can be configured to use an alternative partitioning strategy if desired. Set the configuration property `connector.client.config.override.policy` to value `All` on the Kafka Connect worker (the overall Kafka Connect application that runs plugins). This will allow the override of the internal Kafka producer and consumer configurations. To override the partitioner for an individual connector plugin, add the configuration property `producer.override.partitioner.class` to the connector plugin with a value that points to a class implementing the [Partitioner](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/producer/Partitioner.java) interface, e.g. `org.apache.kafka.clients.producer.internals.DefaultPartitioner`.
 
 ## Parallelization
-Splitting the workload between multiple tasks via the configuration property `max.tasks` is not supported at this time. Support for this will be added in the future.
+Splitting the workload between multiple tasks is possible via the configuration property `max.tasks`. The connector splits the work based on the number of configured channels/patterns. If the `max.tasks` configuration exceeds the number of channels/patterns, the number of channels/patterns will be used instead as the maximum.
 
 ## Configuration
 ### Connector Properties

--- a/docs/connectors/SOURCE.md
+++ b/docs/connectors/SOURCE.md
@@ -82,7 +82,7 @@ In the case of subscribing to Redis keyspace notifications, it may be useful to 
 The plugin can be configured to use an alternative partitioning strategy if desired. Set the configuration property `connector.client.config.override.policy` to value `All` on the Kafka Connect worker (the overall Kafka Connect application that runs plugins). This will allow the override of the internal Kafka producer and consumer configurations. To override the partitioner for an individual connector plugin, add the configuration property `producer.override.partitioner.class` to the connector plugin with a value that points to a class implementing the [Partitioner](https://github.com/apache/kafka/blob/trunk/clients/src/main/java/org/apache/kafka/clients/producer/Partitioner.java) interface, e.g. `org.apache.kafka.clients.producer.internals.DefaultPartitioner`.
 
 ## Parallelization
-Splitting the workload between multiple tasks is possible via the configuration property `max.tasks`. The connector splits the work based on the number of configured channels/patterns. If the `max.tasks` configuration exceeds the number of channels/patterns, the number of channels/patterns will be used instead as the maximum.
+Splitting the workload between multiple tasks is possible via the configuration property `tasks.max`. The connector splits the work based on the number of configured channels/patterns. If the max tasks configuration exceeds the number of channels/patterns, the number of channels/patterns will be used instead as the maximum.
 
 ## Configuration
 ### Connector Properties

--- a/docs/connectors/SOURCE.md
+++ b/docs/connectors/SOURCE.md
@@ -88,7 +88,7 @@ Splitting the workload between multiple tasks is possible via the configuration 
 ### Connector Properties
 | Name                              | Type    | Default        | Importance | Description                                             |
 | --------------------------------- | ------- | -------------- | ---------- | ------------------------------------------------------- |
-| `topic`                           | string  | `redis.events` | High       | Topic to write to.                                      |
+| `topic`                           | string  |                | High       | Topic to write to.                                      |
 | `redis.uri`                       | string  |                | High       | Redis connection information provided via a URI string. |
 | `redis.cluster.enabled`           | boolean | false          | High       | Target Redis is running as a cluster.                   |
 | `redis.channels`                  | string  |                | High       | Redis channels to subscribe to separated by commas.     |

--- a/docs/demo/README.md
+++ b/docs/demo/README.md
@@ -27,7 +27,7 @@ docker build -t jaredpetersen/redis:latest .
 
 Next, we'll need to build a docker image for Kafka Connect Redis. Navigate to `demo/docker/kafka-connect-redis` and run the following commands:
 ```bash
-curl -O https://oss.sonatype.org/service/local/repositories/releases/content/io/github/jaredpetersen/kafka-connect-redis/1.0.4/kafka-connect-redis-1.0.4.jar
+curl -O https://repo1.maven.org/maven2/io/github/jaredpetersen/kafka-connect-redis/1.1.0/kafka-connect-redis-1.1.0.jar
 docker build -t jaredpetersen/kafka-connect-redis:latest .
 ```
 

--- a/docs/demo/SINK.md
+++ b/docs/demo/SINK.md
@@ -17,7 +17,7 @@ curl --request POST \
             "key.converter.schema.registry.url": "http://kafka-schema-registry:8081",
             "value.converter": "io.confluent.connect.avro.AvroConverter",
             "value.converter.schema.registry.url": "http://kafka-schema-registry:8081",
-            "tasks.max": "1",
+            "tasks.max": "3",
             "topics": "redis.commands.set,redis.commands.expire,redis.commands.expireat,redis.commands.pexpire,redis.commands.sadd,redis.commands.geoadd,redis.commands.arbitrary",
             "redis.uri": "redis://IEPfIr0eLF7UsfwrIlzy80yUaBG258j9@redis-cluster",
             "redis.cluster.enabled": true

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.github.jaredpetersen</groupId>
   <artifactId>kafka-connect-redis</artifactId>
-  <version>1.0.4</version>
+  <version>1.1.0</version>
   <packaging>jar</packaging>
 
   <name>kafka-connect-redis</name>

--- a/src/main/java/io/github/jaredpetersen/kafkaconnectredis/sink/RedisSinkConnector.java
+++ b/src/main/java/io/github/jaredpetersen/kafkaconnectredis/sink/RedisSinkConnector.java
@@ -6,14 +6,16 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.connector.Task;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkConnector;
 
 /**
  * Entry point for Kafka Connect Redis Sink.
  */
 public class RedisSinkConnector extends SinkConnector {
-  private Map<String, String> config;
+  private RedisSinkConfig config;
 
   @Override
   public String version() {
@@ -22,7 +24,12 @@ public class RedisSinkConnector extends SinkConnector {
 
   @Override
   public void start(final Map<String, String> props) {
-    this.config = props;
+    try {
+      this.config = new RedisSinkConfig(props);
+    }
+    catch (ConfigException configException) {
+      throw new ConnectException("connector configuration error");
+    }
   }
 
   @Override
@@ -35,7 +42,7 @@ public class RedisSinkConnector extends SinkConnector {
     List<Map<String, String>> taskConfigs = new ArrayList<>(maxTasks);
 
     for (int configIndex = 0; configIndex < maxTasks; ++configIndex) {
-      taskConfigs.add(this.config);
+      taskConfigs.add(this.config.originalsStrings());
     }
 
     return taskConfigs;

--- a/src/main/java/io/github/jaredpetersen/kafkaconnectredis/sink/RedisSinkTask.java
+++ b/src/main/java/io/github/jaredpetersen/kafkaconnectredis/sink/RedisSinkTask.java
@@ -48,7 +48,8 @@ public class RedisSinkTask extends SinkTask {
 
     try {
       config = new RedisSinkConfig(props);
-    } catch(ConfigException configException) {
+    }
+    catch (ConfigException configException) {
       throw new ConnectException("task configuration error");
     }
 

--- a/src/main/java/io/github/jaredpetersen/kafkaconnectredis/sink/config/RedisSinkConfig.java
+++ b/src/main/java/io/github/jaredpetersen/kafkaconnectredis/sink/config/RedisSinkConfig.java
@@ -8,11 +8,11 @@ import org.apache.kafka.common.config.ConfigDef.Type;
 
 public class RedisSinkConfig extends AbstractConfig {
   // TODO Store as password
-  private static final String REDIS_URI = "redis.uri";
+  public static final String REDIS_URI = "redis.uri";
   private static final String REDIS_URI_DOC = "Redis uri.";
   private final String redisUri;
 
-  private static final String REDIS_CLUSTER_ENABLED = "redis.cluster.enabled";
+  public static final String REDIS_CLUSTER_ENABLED = "redis.cluster.enabled";
   private static final String REDIS_CLUSTER_ENABLED_DOC = "Redis cluster mode enabled.";
   private static final boolean REDIS_CLUSTER_ENABLED_DEFAULT = false;
   private final boolean redisClusterEnabled;

--- a/src/main/java/io/github/jaredpetersen/kafkaconnectredis/sink/config/RedisSinkConfig.java
+++ b/src/main/java/io/github/jaredpetersen/kafkaconnectredis/sink/config/RedisSinkConfig.java
@@ -7,7 +7,6 @@ import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 
 public class RedisSinkConfig extends AbstractConfig {
-  // TODO Store as password
   public static final String REDIS_URI = "redis.uri";
   private static final String REDIS_URI_DOC = "Redis uri.";
   private final String redisUri;

--- a/src/main/java/io/github/jaredpetersen/kafkaconnectredis/source/RedisSourceConnector.java
+++ b/src/main/java/io/github/jaredpetersen/kafkaconnectredis/source/RedisSourceConnector.java
@@ -2,18 +2,25 @@ package io.github.jaredpetersen.kafkaconnectredis.source;
 
 import io.github.jaredpetersen.kafkaconnectredis.source.config.RedisSourceConfig;
 import io.github.jaredpetersen.kafkaconnectredis.util.VersionUtil;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 import org.apache.kafka.common.config.ConfigDef;
+import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.connector.Task;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceConnector;
+import org.apache.kafka.connect.util.ConnectorUtils;
 
 /**
  * Entry point for Kafka Connect Redis Sink.
  */
 public class RedisSourceConnector extends SourceConnector {
-  private Map<String, String> config;
+  private RedisSourceConfig config;
 
   @Override
   public String version() {
@@ -22,7 +29,13 @@ public class RedisSourceConnector extends SourceConnector {
 
   @Override
   public void start(final Map<String, String> props) {
-    this.config = props;
+    // Map the connector properties to config object
+    try {
+      this.config = new RedisSourceConfig(props);
+    }
+    catch (ConfigException configException) {
+      throw new ConnectException("connector configuration error", configException);
+    }
   }
 
   @Override
@@ -32,8 +45,19 @@ public class RedisSourceConnector extends SourceConnector {
 
   @Override
   public List<Map<String, String>> taskConfigs(final int maxTasks) {
-    // TODO create a task for each channel/pattern
-    return Collections.singletonList(this.config);
+    // Partition the configs based on channels
+    final List<List<String>> partitionedRedisChannels = ConnectorUtils
+      .groupPartitions(this.config.getRedisChannels(), Math.min(this.config.getRedisChannels().size(), maxTasks));
+
+    // Create task configs based on the partitions
+    return partitionedRedisChannels.stream()
+      .map(redisChannels -> {
+        final Map<String, String> taskConfig = new HashMap<>(this.config.originalsStrings());
+        taskConfig.put(RedisSourceConfig.REDIS_CHANNELS, String.join(",", redisChannels));
+
+        return taskConfig;
+      })
+      .collect(Collectors.toList());
   }
 
   @Override

--- a/src/main/java/io/github/jaredpetersen/kafkaconnectredis/source/RedisSourceConnector.java
+++ b/src/main/java/io/github/jaredpetersen/kafkaconnectredis/source/RedisSourceConnector.java
@@ -44,7 +44,8 @@ public class RedisSourceConnector extends SourceConnector {
   }
 
   @Override
-  public List<Map<String, String>> taskConfigs(final int maxTasks) {
+  public List<Map<String, String>> taskConfigs(final int
+                                                   maxTasks) {
     // Partition the configs based on channels
     final List<List<String>> partitionedRedisChannels = ConnectorUtils
       .groupPartitions(this.config.getRedisChannels(), Math.min(this.config.getRedisChannels().size(), maxTasks));

--- a/src/main/java/io/github/jaredpetersen/kafkaconnectredis/source/RedisSourceConnector.java
+++ b/src/main/java/io/github/jaredpetersen/kafkaconnectredis/source/RedisSourceConnector.java
@@ -2,9 +2,6 @@ package io.github.jaredpetersen.kafkaconnectredis.source;
 
 import io.github.jaredpetersen.kafkaconnectredis.source.config.RedisSourceConfig;
 import io.github.jaredpetersen.kafkaconnectredis.util.VersionUtil;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;

--- a/src/main/java/io/github/jaredpetersen/kafkaconnectredis/source/RedisSourceConnector.java
+++ b/src/main/java/io/github/jaredpetersen/kafkaconnectredis/source/RedisSourceConnector.java
@@ -41,8 +41,7 @@ public class RedisSourceConnector extends SourceConnector {
   }
 
   @Override
-  public List<Map<String, String>> taskConfigs(final int
-                                                   maxTasks) {
+  public List<Map<String, String>> taskConfigs(final int maxTasks) {
     // Partition the configs based on channels
     final List<List<String>> partitionedRedisChannels = ConnectorUtils
       .groupPartitions(this.config.getRedisChannels(), Math.min(this.config.getRedisChannels().size(), maxTasks));

--- a/src/main/java/io/github/jaredpetersen/kafkaconnectredis/source/RedisSourceTask.java
+++ b/src/main/java/io/github/jaredpetersen/kafkaconnectredis/source/RedisSourceTask.java
@@ -51,7 +51,7 @@ public class RedisSourceTask extends SourceTask {
     try {
       config = new RedisSourceConfig(props);
     }
-    catch(ConfigException configException) {
+    catch (ConfigException configException) {
       throw new ConnectException("task configuration error", configException);
     }
 

--- a/src/main/java/io/github/jaredpetersen/kafkaconnectredis/source/RedisSourceTask.java
+++ b/src/main/java/io/github/jaredpetersen/kafkaconnectredis/source/RedisSourceTask.java
@@ -55,7 +55,7 @@ public class RedisSourceTask extends SourceTask {
       throw new ConnectException("task configuration error", configException);
     }
 
-    // Set up the pub/sub subscriber for Redis
+    // Set up the subscriber for Redis
     final RedisSubscriber redisSubscriber;
 
     if (config.isRedisClusterEnabled()) {

--- a/src/main/java/io/github/jaredpetersen/kafkaconnectredis/source/RedisSourceTask.java
+++ b/src/main/java/io/github/jaredpetersen/kafkaconnectredis/source/RedisSourceTask.java
@@ -15,6 +15,8 @@ import io.lettuce.core.cluster.pubsub.StatefulRedisClusterPubSubConnection;
 import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
 import java.util.List;
 import java.util.Map;
+import org.apache.kafka.common.config.ConfigException;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
 import org.slf4j.Logger;
@@ -44,8 +46,16 @@ public class RedisSourceTask extends SourceTask {
   @Override
   public void start(Map<String, String> props) {
     // Map the task properties to config object
-    final RedisSourceConfig config = new RedisSourceConfig(props);
+    final RedisSourceConfig config;
 
+    try {
+      config = new RedisSourceConfig(props);
+    }
+    catch(ConfigException configException) {
+      throw new ConnectException("task configuration error", configException);
+    }
+
+    // Set up the pub/sub subscriber for Redis
     final RedisSubscriber redisSubscriber;
 
     if (config.isRedisClusterEnabled()) {

--- a/src/main/java/io/github/jaredpetersen/kafkaconnectredis/source/config/RedisSourceConfig.java
+++ b/src/main/java/io/github/jaredpetersen/kafkaconnectredis/source/config/RedisSourceConfig.java
@@ -8,25 +8,25 @@ import org.apache.kafka.common.config.ConfigDef.Importance;
 import org.apache.kafka.common.config.ConfigDef.Type;
 
 public class RedisSourceConfig extends AbstractConfig {
-  private static final String TOPIC = "topic";
+  public static final String TOPIC = "topic";
   private static final String TOPIC_DOC = "Topic to write to.";
   private static final String TOPIC_DEFAULT = "redis";
   private final String topic;
 
-  private static final String REDIS_URI = "redis.uri";
+  public static final String REDIS_URI = "redis.uri";
   private static final String REDIS_URI_DOC = "Redis uri.";
   private final String redisUri;
 
-  private static final String REDIS_CLUSTER_ENABLED = "redis.cluster.enabled";
+  public static final String REDIS_CLUSTER_ENABLED = "redis.cluster.enabled";
   private static final String REDIS_CLUSTER_ENABLED_DOC = "Redis cluster mode enabled.";
   private static final boolean REDIS_CLUSTER_ENABLED_DEFAULT = false;
   private final boolean redisClusterEnabled;
 
-  private static final String REDIS_CHANNELS = "redis.channels";
+  public static final String REDIS_CHANNELS = "redis.channels";
   private static final String REDIS_CHANNELS_DOC = "Redis channel(s) to subscribe to, comma-separated.";
   private final List<String> redisChannels;
 
-  private static final String REDIS_CHANNELS_PATTERN_ENABLED = "redis.channels.pattern.enabled";
+  public static final String REDIS_CHANNELS_PATTERN_ENABLED = "redis.channels.pattern.enabled";
   private static final String REDIS_CHANNELS_PATTERN_ENABLED_DOC = "Redis channel(s) utilize patterns.";
   private final boolean redisChannelPatternEnabled;
 

--- a/src/main/java/io/github/jaredpetersen/kafkaconnectredis/source/config/RedisSourceConfig.java
+++ b/src/main/java/io/github/jaredpetersen/kafkaconnectredis/source/config/RedisSourceConfig.java
@@ -10,7 +10,6 @@ import org.apache.kafka.common.config.ConfigDef.Type;
 public class RedisSourceConfig extends AbstractConfig {
   public static final String TOPIC = "topic";
   private static final String TOPIC_DOC = "Topic to write to.";
-  private static final String TOPIC_DEFAULT = "redis";
   private final String topic;
 
   public static final String REDIS_URI = "redis.uri";
@@ -34,7 +33,6 @@ public class RedisSourceConfig extends AbstractConfig {
     .define(
       TOPIC,
       Type.STRING,
-      TOPIC_DEFAULT,
       Importance.HIGH,
       TOPIC_DOC)
     .define(

--- a/src/test/integration/java/io/github/jaredpetersen/kafkaconnectredis/sink/RedisSinkConnectorIT.java
+++ b/src/test/integration/java/io/github/jaredpetersen/kafkaconnectredis/sink/RedisSinkConnectorIT.java
@@ -1,13 +1,16 @@
 package io.github.jaredpetersen.kafkaconnectredis.sink;
 
 import io.github.jaredpetersen.kafkaconnectredis.sink.config.RedisSinkConfig;
+import io.github.jaredpetersen.kafkaconnectredis.source.RedisSourceConnector;
 import io.github.jaredpetersen.kafkaconnectredis.util.VersionUtil;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RedisSinkConnectorIT {
   @Test
@@ -40,6 +43,17 @@ public class RedisSinkConnectorIT {
     assertEquals(connectorConfig, taskConfigs.get(0));
     assertEquals(connectorConfig, taskConfigs.get(1));
     assertEquals(connectorConfig, taskConfigs.get(2));
+  }
+
+  @Test
+  public void startThrowsConnectExceptionForInvalidConfig() {
+    final RedisSourceConnector sourceConnector = new RedisSourceConnector();
+
+    final Map<String, String> connectorConfig = new HashMap<>();
+    connectorConfig.put("redis.uri", "redis://localhost:6379");
+
+    final ConnectException thrown = assertThrows(ConnectException.class, () -> sourceConnector.start(connectorConfig));
+    assertEquals("connector configuration error", thrown.getMessage());
   }
 
   @Test

--- a/src/test/integration/java/io/github/jaredpetersen/kafkaconnectredis/sink/RedisSinkTaskIT.java
+++ b/src/test/integration/java/io/github/jaredpetersen/kafkaconnectredis/sink/RedisSinkTaskIT.java
@@ -1,6 +1,5 @@
 package io.github.jaredpetersen.kafkaconnectredis.sink;
 
-import io.github.jaredpetersen.kafkaconnectredis.source.RedisSourceConnector;
 import io.github.jaredpetersen.kafkaconnectredis.util.VersionUtil;
 import io.lettuce.core.RedisClient;
 import io.lettuce.core.api.StatefulRedisConnection;

--- a/src/test/integration/java/io/github/jaredpetersen/kafkaconnectredis/source/RedisSourceConnectorIT.java
+++ b/src/test/integration/java/io/github/jaredpetersen/kafkaconnectredis/source/RedisSourceConnectorIT.java
@@ -31,6 +31,7 @@ public class RedisSourceConnectorIT {
     final RedisSourceConnector sourceConnector = new RedisSourceConnector();
 
     final Map<String, String> connectorConfig = new HashMap<>();
+    connectorConfig.put("topic", "mytopic");
     connectorConfig.put("redis.uri", "redis://localhost:6379");
     connectorConfig.put("redis.cluster.enabled", "false");
     connectorConfig.put("redis.channels", "channel1,channel2,channel3");
@@ -49,18 +50,21 @@ public class RedisSourceConnectorIT {
     final RedisSourceConnector sourceConnector = new RedisSourceConnector();
 
     final Map<String, String> connectorConfig = new HashMap<>();
+    connectorConfig.put("topic", "mytopic");
     connectorConfig.put("redis.uri", "redis://localhost:6379");
     connectorConfig.put("redis.cluster.enabled", "false");
     connectorConfig.put("redis.channels", "channel1,channel2,channel3");
     connectorConfig.put("redis.channels.pattern.enabled", "false");
 
     final Map<String, String> expectedPartitionedConnectorConfigA = new HashMap<>();
+    expectedPartitionedConnectorConfigA.put("topic", "mytopic");
     expectedPartitionedConnectorConfigA.put("redis.uri", "redis://localhost:6379");
     expectedPartitionedConnectorConfigA.put("redis.cluster.enabled", "false");
     expectedPartitionedConnectorConfigA.put("redis.channels", "channel1,channel2");
     expectedPartitionedConnectorConfigA.put("redis.channels.pattern.enabled", "false");
 
     final Map<String, String> expectedPartitionedConnectorConfigB = new HashMap<>();
+    expectedPartitionedConnectorConfigB.put("topic", "mytopic");
     expectedPartitionedConnectorConfigB.put("redis.uri", "redis://localhost:6379");
     expectedPartitionedConnectorConfigB.put("redis.cluster.enabled", "false");
     expectedPartitionedConnectorConfigB.put("redis.channels", "channel3");
@@ -80,24 +84,28 @@ public class RedisSourceConnectorIT {
     final RedisSourceConnector sourceConnector = new RedisSourceConnector();
 
     final Map<String, String> connectorConfig = new HashMap<>();
+    connectorConfig.put("topic", "mytopic");
     connectorConfig.put("redis.uri", "redis://localhost:6379");
     connectorConfig.put("redis.cluster.enabled", "false");
     connectorConfig.put("redis.channels", "channel1,channel2,channel3");
     connectorConfig.put("redis.channels.pattern.enabled", "false");
 
     final Map<String, String> expectedPartitionedConnectorConfigA = new HashMap<>();
+    expectedPartitionedConnectorConfigA.put("topic", "mytopic");
     expectedPartitionedConnectorConfigA.put("redis.uri", "redis://localhost:6379");
     expectedPartitionedConnectorConfigA.put("redis.cluster.enabled", "false");
     expectedPartitionedConnectorConfigA.put("redis.channels", "channel1");
     expectedPartitionedConnectorConfigA.put("redis.channels.pattern.enabled", "false");
 
     final Map<String, String> expectedPartitionedConnectorConfigB = new HashMap<>();
+    expectedPartitionedConnectorConfigB.put("topic", "mytopic");
     expectedPartitionedConnectorConfigB.put("redis.uri", "redis://localhost:6379");
     expectedPartitionedConnectorConfigB.put("redis.cluster.enabled", "false");
     expectedPartitionedConnectorConfigB.put("redis.channels", "channel2");
     expectedPartitionedConnectorConfigB.put("redis.channels.pattern.enabled", "false");
 
     final Map<String, String> expectedPartitionedConnectorConfigC = new HashMap<>();
+    expectedPartitionedConnectorConfigC.put("topic", "mytopic");
     expectedPartitionedConnectorConfigC.put("redis.uri", "redis://localhost:6379");
     expectedPartitionedConnectorConfigC.put("redis.cluster.enabled", "false");
     expectedPartitionedConnectorConfigC.put("redis.channels", "channel3");

--- a/src/test/integration/java/io/github/jaredpetersen/kafkaconnectredis/source/RedisSourceConnectorIT.java
+++ b/src/test/integration/java/io/github/jaredpetersen/kafkaconnectredis/source/RedisSourceConnectorIT.java
@@ -5,9 +5,11 @@ import io.github.jaredpetersen.kafkaconnectredis.util.VersionUtil;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class RedisSourceConnectorIT {
   @Test
@@ -31,13 +33,95 @@ public class RedisSourceConnectorIT {
     final Map<String, String> connectorConfig = new HashMap<>();
     connectorConfig.put("redis.uri", "redis://localhost:6379");
     connectorConfig.put("redis.cluster.enabled", "false");
+    connectorConfig.put("redis.channels", "channel1,channel2,channel3");
+    connectorConfig.put("redis.channels.pattern.enabled", "false");
 
     sourceConnector.start(connectorConfig);
 
-    final List<Map<String, String>> taskConfigs = sourceConnector.taskConfigs(3);
+    final List<Map<String, String>> taskConfigs = sourceConnector.taskConfigs(1);
 
     assertEquals(1, taskConfigs.size());
     assertEquals(connectorConfig, taskConfigs.get(0));
+  }
+
+  @Test
+  public void taskConfigsReturnsPartitionedTaskConfigs() {
+    final RedisSourceConnector sourceConnector = new RedisSourceConnector();
+
+    final Map<String, String> connectorConfig = new HashMap<>();
+    connectorConfig.put("redis.uri", "redis://localhost:6379");
+    connectorConfig.put("redis.cluster.enabled", "false");
+    connectorConfig.put("redis.channels", "channel1,channel2,channel3");
+    connectorConfig.put("redis.channels.pattern.enabled", "false");
+
+    final Map<String, String> expectedPartitionedConnectorConfigA = new HashMap<>();
+    expectedPartitionedConnectorConfigA.put("redis.uri", "redis://localhost:6379");
+    expectedPartitionedConnectorConfigA.put("redis.cluster.enabled", "false");
+    expectedPartitionedConnectorConfigA.put("redis.channels", "channel1,channel2");
+    expectedPartitionedConnectorConfigA.put("redis.channels.pattern.enabled", "false");
+
+    final Map<String, String> expectedPartitionedConnectorConfigB = new HashMap<>();
+    expectedPartitionedConnectorConfigB.put("redis.uri", "redis://localhost:6379");
+    expectedPartitionedConnectorConfigB.put("redis.cluster.enabled", "false");
+    expectedPartitionedConnectorConfigB.put("redis.channels", "channel3");
+    expectedPartitionedConnectorConfigB.put("redis.channels.pattern.enabled", "false");
+
+    sourceConnector.start(connectorConfig);
+
+    final List<Map<String, String>> taskConfigs = sourceConnector.taskConfigs(2);
+
+    assertEquals(2, taskConfigs.size());
+    assertEquals(expectedPartitionedConnectorConfigA, taskConfigs.get(0));
+    assertEquals(expectedPartitionedConnectorConfigB, taskConfigs.get(1));
+  }
+
+  @Test
+  public void taskConfigsReturnsPartitionedTaskConfigsWithExcessiveMaxTask() {
+    final RedisSourceConnector sourceConnector = new RedisSourceConnector();
+
+    final Map<String, String> connectorConfig = new HashMap<>();
+    connectorConfig.put("redis.uri", "redis://localhost:6379");
+    connectorConfig.put("redis.cluster.enabled", "false");
+    connectorConfig.put("redis.channels", "channel1,channel2,channel3");
+    connectorConfig.put("redis.channels.pattern.enabled", "false");
+
+    final Map<String, String> expectedPartitionedConnectorConfigA = new HashMap<>();
+    expectedPartitionedConnectorConfigA.put("redis.uri", "redis://localhost:6379");
+    expectedPartitionedConnectorConfigA.put("redis.cluster.enabled", "false");
+    expectedPartitionedConnectorConfigA.put("redis.channels", "channel1");
+    expectedPartitionedConnectorConfigA.put("redis.channels.pattern.enabled", "false");
+
+    final Map<String, String> expectedPartitionedConnectorConfigB = new HashMap<>();
+    expectedPartitionedConnectorConfigB.put("redis.uri", "redis://localhost:6379");
+    expectedPartitionedConnectorConfigB.put("redis.cluster.enabled", "false");
+    expectedPartitionedConnectorConfigB.put("redis.channels", "channel2");
+    expectedPartitionedConnectorConfigB.put("redis.channels.pattern.enabled", "false");
+
+    final Map<String, String> expectedPartitionedConnectorConfigC = new HashMap<>();
+    expectedPartitionedConnectorConfigC.put("redis.uri", "redis://localhost:6379");
+    expectedPartitionedConnectorConfigC.put("redis.cluster.enabled", "false");
+    expectedPartitionedConnectorConfigC.put("redis.channels", "channel3");
+    expectedPartitionedConnectorConfigC.put("redis.channels.pattern.enabled", "false");
+
+    sourceConnector.start(connectorConfig);
+
+    final List<Map<String, String>> taskConfigs = sourceConnector.taskConfigs(40);
+
+    assertEquals(3, taskConfigs.size());
+    assertEquals(expectedPartitionedConnectorConfigA, taskConfigs.get(0));
+    assertEquals(expectedPartitionedConnectorConfigB, taskConfigs.get(1));
+    assertEquals(expectedPartitionedConnectorConfigC, taskConfigs.get(2));
+  }
+
+  @Test
+  public void startThrowsConnectExceptionForInvalidConfig() {
+    final RedisSourceConnector sourceConnector = new RedisSourceConnector();
+
+    final Map<String, String> connectorConfig = new HashMap<>();
+    connectorConfig.put("redis.uri", "redis://localhost:6379");
+
+    final ConnectException thrown = assertThrows(ConnectException.class, () -> sourceConnector.start(connectorConfig));
+    assertEquals("connector configuration error", thrown.getMessage());
   }
 
   @Test

--- a/src/test/integration/java/io/github/jaredpetersen/kafkaconnectredis/source/RedisSourceTaskIT.java
+++ b/src/test/integration/java/io/github/jaredpetersen/kafkaconnectredis/source/RedisSourceTaskIT.java
@@ -10,6 +10,7 @@ import io.lettuce.core.pubsub.StatefulRedisPubSubConnection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.source.SourceRecord;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
@@ -25,6 +26,7 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 @Testcontainers
 public class RedisSourceTaskIT {
@@ -230,6 +232,17 @@ public class RedisSourceTaskIT {
     final List<SourceRecord> sourceRecords = sourceTask.poll();
 
     assertEquals(0, sourceRecords.size());
+  }
+
+  @Test
+  public void startThrowsConnectExceptionForInvalidConfig() {
+    final RedisSourceTask sourceTask = new RedisSourceTask();
+
+    final Map<String, String> taskConfig = new HashMap<>();
+    taskConfig.put("redis.uri", REDIS_STANDALONE_URI);
+
+    final ConnectException thrown = assertThrows(ConnectException.class, () -> sourceTask.start(taskConfig));
+    assertEquals("task configuration error", thrown.getMessage());
   }
 
   @Test

--- a/src/test/integration/java/io/github/jaredpetersen/kafkaconnectredis/source/RedisSourceTaskIT.java
+++ b/src/test/integration/java/io/github/jaredpetersen/kafkaconnectredis/source/RedisSourceTaskIT.java
@@ -102,6 +102,7 @@ public class RedisSourceTaskIT {
     final RedisSourceTask sourceTask = new RedisSourceTask();
 
     final Map<String, String> config = new HashMap<>();
+    config.put("topic", "mytopic");
     config.put("redis.uri", REDIS_STANDALONE_URI);
     config.put("redis.cluster.enabled", "false");
     config.put("redis.channels", "boats");
@@ -132,6 +133,7 @@ public class RedisSourceTaskIT {
     final RedisSourceTask sourceTask = new RedisSourceTask();
 
     final Map<String, String> config = new HashMap<>();
+    config.put("topic", "mytopic");
     config.put("redis.uri", REDIS_STANDALONE_URI);
     config.put("redis.cluster.enabled", "false");
     config.put("redis.channels", "boat*");
@@ -162,6 +164,7 @@ public class RedisSourceTaskIT {
     final RedisSourceTask sourceTask = new RedisSourceTask();
 
     final Map<String, String> config = new HashMap<>();
+    config.put("topic", "mytopic");
     config.put("redis.uri", REDIS_CLUSTER_URI);
     config.put("redis.cluster.enabled", "true");
     config.put("redis.channels", "boats");
@@ -192,6 +195,7 @@ public class RedisSourceTaskIT {
     final RedisSourceTask sourceTask = new RedisSourceTask();
 
     final Map<String, String> config = new HashMap<>();
+    config.put("topic", "mytopic");
     config.put("redis.uri", REDIS_CLUSTER_URI);
     config.put("redis.cluster.enabled", "true");
     config.put("redis.channels", "boat*");
@@ -222,6 +226,7 @@ public class RedisSourceTaskIT {
     final RedisSourceTask sourceTask = new RedisSourceTask();
 
     final Map<String, String> config = new HashMap<>();
+    config.put("topic", "mytopic");
     config.put("redis.uri", REDIS_STANDALONE_URI);
     config.put("redis.cluster.enabled", "false");
     config.put("redis.channels", "boats");
@@ -250,6 +255,7 @@ public class RedisSourceTaskIT {
     final RedisSourceTask sourceTask = new RedisSourceTask();
 
     final Map<String, String> config = new HashMap<>();
+    config.put("topic", "mytopic");
     config.put("redis.uri", REDIS_STANDALONE_URI);
     config.put("redis.cluster.enabled", "false");
     config.put("redis.channels", "boats");
@@ -264,6 +270,7 @@ public class RedisSourceTaskIT {
     final RedisSourceTask sourceTask = new RedisSourceTask();
 
     final Map<String, String> config = new HashMap<>();
+    config.put("topic", "mytopic");
     config.put("redis.uri", REDIS_CLUSTER_URI);
     config.put("redis.cluster.enabled", "true");
     config.put("redis.channels", "boat*");

--- a/src/test/unit/java/io/github/jaredpetersen/kafkaconnectredis/source/config/RedisSourceConfigTest.java
+++ b/src/test/unit/java/io/github/jaredpetersen/kafkaconnectredis/source/config/RedisSourceConfigTest.java
@@ -12,18 +12,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 
 public class RedisSourceConfigTest {
   @Test
-  public void getTopicReturnsDefaultTopic() {
-    final Map<String, Object> originalConfig = new HashMap<>();
-    originalConfig.put("redis.uri", "redis://localhost:6379");
-    originalConfig.put("redis.channels", "channel1,channel2");
-    originalConfig.put("redis.channels.pattern.enabled", true);
-
-    final RedisSourceConfig sinkConfig = new RedisSourceConfig(originalConfig);
-
-    assertEquals("redis", sinkConfig.getTopic());
-  }
-
-  @Test
   public void getTopicReturnsTopic() {
     final Map<String, Object> originalConfig = new HashMap<>();
     originalConfig.put("topic", "mytopic");
@@ -39,6 +27,7 @@ public class RedisSourceConfigTest {
   @Test
   public void getRedisUriReturnsUri() {
     final Map<String, Object> originalConfig = new HashMap<>();
+    originalConfig.put("topic", "mytopic");
     originalConfig.put("redis.uri", "redis://localhost:6379");
     originalConfig.put("redis.channels", "channel1,channel2");
     originalConfig.put("redis.channels.pattern.enabled", true);
@@ -51,6 +40,7 @@ public class RedisSourceConfigTest {
   @Test
   public void isRedisClusterEnabledReturnsDefaultStatus() {
     final Map<String, Object> originalConfig = new HashMap<>();
+    originalConfig.put("topic", "mytopic");
     originalConfig.put("redis.uri", "redis://localhost:6379");
     originalConfig.put("redis.channels", "channel1,channel2");
     originalConfig.put("redis.channels.pattern.enabled", true);
@@ -64,6 +54,7 @@ public class RedisSourceConfigTest {
   @ValueSource(booleans = { true, false })
   public void isRedisClusterEnabledReturnsStatus(boolean status) {
     final Map<String, Object> originalConfig = new HashMap<>();
+    originalConfig.put("topic", "mytopic");
     originalConfig.put("redis.uri", "redis://localhost:6379");
     originalConfig.put("redis.cluster.enabled", status);
     originalConfig.put("redis.channels", "channel1,channel2");


### PR DESCRIPTION
Added parallelization to the source connector based on the configured channels/patterns. 

Also:
- Cleaned up how connector configuration is being ingested so that configuration errors are properly bubbled up
- Removed the default topic configuration for the sink connector since the default value causes confusion