### PR TITLE
Updated redis source timestamp from seconds to milliseconds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.3] - 2022-03-15
+### Fixed
+- Fixed a bug with record timestamps for the source connector -- switched from incorrect epoch second to epoch millisecond
+
 ## [1.2.2] - 2021-07-22
 ### Changed
 - Use capitalization in log messages

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [1.2.3] - 2022-03-15
 ### Fixed
-- Fixed a bug with record timestamps for the source connector -- switched from incorrect epoch second to epoch millisecond
+- Fixed a bug with record timestamps for the source connector -- switched from epoch seconds (incorrect) to epoch milliseconds
 
 ## [1.2.2] - 2021-07-22
 ### Changed

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
   <groupId>io.github.jaredpetersen</groupId>
   <artifactId>kafka-connect-redis</artifactId>
-  <version>1.2.2</version>
+  <version>1.2.3</version>
   <packaging>jar</packaging>
 
   <name>Kafka Redis Connector (Sink and Source)</name>

--- a/src/main/java/io/github/jaredpetersen/kafkaconnectredis/source/listener/RecordConverter.java
+++ b/src/main/java/io/github/jaredpetersen/kafkaconnectredis/source/listener/RecordConverter.java
@@ -55,7 +55,7 @@ public class RecordConverter {
       key,
       VALUE_SCHEMA,
       value,
-      Instant.now().getEpochSecond()
+      Instant.now().toEpochMilli()
     );
   }
 }

--- a/src/test/unit/java/io/github/jaredpetersen/kafkaconnectredis/source/listener/RecordConverterTest.java
+++ b/src/test/unit/java/io/github/jaredpetersen/kafkaconnectredis/source/listener/RecordConverterTest.java
@@ -32,6 +32,6 @@ class RecordConverterTest {
     assertEquals(redisMessage.getPattern(), ((Struct) sourceRecord.key()).getString("pattern"));
     assertEquals(Schema.Type.STRUCT, sourceRecord.valueSchema().type());
     assertEquals(redisMessage.getMessage(), ((Struct) sourceRecord.value()).getString("message"));
-    assertTrue(sourceRecord.timestamp() <= Instant.now().getEpochSecond());
+    assertTrue(sourceRecord.timestamp() <= Instant.now().toEpochMilli());
   }
 }


### PR DESCRIPTION
updated SourceRecord timestamp parameter from seconds to milliseconds.

The redis connector was adding timestamp in seconds instead of milliseconds, this created event timestamp in 1970 year. The record gets removed by the Kafka because of retention policy of few days.

Steps to reproduce:

create redis source connector with necessary config
start connector and produce redis events 
check events in kafka topic (mentioned in connector config) , Kafka topic should have few days of 
check 1 : check timestamp of message (it is in seconds since epoch instead of millisecond)
check 2 : try to consume events from kafka topic from --from-beginning after 5 mins of event produce , the redis event won't be there anymore