### PR TITLE
Add redis sentinel support for sink connector

### DIFF
--- a/docs/demo/SINK.md
+++ b/docs/demo/SINK.md
@@ -10,6 +10,9 @@ kubectl -n kcr-demo port-forward service/kafka-connect :rest
 Kubectl will choose an available port for you that you will need to use for the cURLs. Set this port to `$PORT`.
 
 ### Avro
+
+#### Cluster Mode
+
 ```bash
 curl --request POST \
     --url "localhost:$PORT/connectors" \
@@ -32,7 +35,38 @@ curl --request POST \
     }'
 ```
 
+
+
+#### Sentinel Mode
+
+```bash
+curl --request POST \
+    --url "localhost:$PORT/connectors" \
+    --header 'content-type: application/json' \
+    --data '{
+        "name": "demo-redis-sink-connector",
+        "config": {
+            "connector.class": "io.github.jaredpetersen.kafkaconnectredis.sink.RedisSinkConnector",
+            "key.converter": "io.confluent.connect.avro.AvroConverter",
+            "key.converter.schema.registry.url": "http://kafka-schema-registry:8081",
+            "key.converter.key.subject.name.strategy": "io.confluent.kafka.serializers.subject.TopicRecordNameStrategy",
+            "value.converter": "io.confluent.connect.avro.AvroConverter",
+            "value.converter.schema.registry.url": "http://kafka-schema-registry:8081",
+            "value.converter.value.subject.name.strategy": "io.confluent.kafka.serializers.subject.TopicRecordNameStrategy",
+            "tasks.max": "3",
+            "topics": "redis.commands",
+            "redis.uri": "redis-sentinel://redispassword@redis-sentinel:26379?sentinelMasterId=mymaster&sentinelAuth=sentinelpassword",
+            "redis.cluster.enabled": false
+        }
+    }'
+```
+
+
+
 ### Connect JSON
+
+#### Cluster Mode
+
 ```bash
 curl --request POST \
     --url "localhost:$PORT/connectors" \
@@ -51,7 +85,32 @@ curl --request POST \
     }'
 ```
 
+
+
+#### Sentinel Mode
+
+```bash
+curl --request POST \
+    --url "localhost:$PORT/connectors" \
+    --header 'content-type: application/json' \
+    --data '{
+        "name": "demo-redis-sink-connector",
+        "config": {
+            "connector.class": "io.github.jaredpetersen.kafkaconnectredis.sink.RedisSinkConnector",
+            "key.converter": "org.apache.kafka.connect.json.JsonConverter",
+            "value.converter": "org.apache.kafka.connect.json.JsonConverter",
+            "tasks.max": "1",
+            "topics": "redis.commands",
+            "redis.uri": "redis-sentinel://redispassword@redis-sentinel:26379?sentinelMasterId=mymaster&sentinelAuth=sentinelpassword",
+            "redis.cluster.enabled": false
+        }
+    }'
+```
+
+
+
 ## Write Records
+
 ### Avro
 Create an interactive ephemeral query pod:
 ```bash

--- a/src/main/java/io/github/jaredpetersen/kafkaconnectredis/sink/RedisSinkTask.java
+++ b/src/main/java/io/github/jaredpetersen/kafkaconnectredis/sink/RedisSinkTask.java
@@ -84,7 +84,7 @@ public class RedisSinkTask extends SinkTask {
     else {
       // Add redis sentinel uri connect logic
       // If the sentinel is configured with a password, use the "sentinelAuth" parameter in the url
-      if (config.getRedisUri().startsWith("redis-sentinel")) {
+      if (config.getRedisUri().startsWith(RedisURI.URI_SCHEME_REDIS_SENTINEL)) {
         RedisURI redisUri = RedisURI.create(config.getRedisUri());
         URI uri = URI.create(config.getRedisUri());
         // Sentinel password configuration logic

--- a/src/main/java/io/github/jaredpetersen/kafkaconnectredis/sink/RedisSinkTask.java
+++ b/src/main/java/io/github/jaredpetersen/kafkaconnectredis/sink/RedisSinkTask.java
@@ -5,7 +5,9 @@ import io.github.jaredpetersen.kafkaconnectredis.sink.writer.RecordConverter;
 import io.github.jaredpetersen.kafkaconnectredis.sink.writer.Writer;
 import io.github.jaredpetersen.kafkaconnectredis.sink.writer.record.RedisCommand;
 import io.github.jaredpetersen.kafkaconnectredis.util.VersionUtil;
+import io.lettuce.core.ReadFrom;
 import io.lettuce.core.RedisClient;
+import io.lettuce.core.RedisURI;
 import io.lettuce.core.api.StatefulRedisConnection;
 import io.lettuce.core.api.sync.RedisCommands;
 import io.lettuce.core.cluster.ClusterClientOptions;
@@ -13,23 +15,34 @@ import io.lettuce.core.cluster.ClusterTopologyRefreshOptions;
 import io.lettuce.core.cluster.RedisClusterClient;
 import io.lettuce.core.cluster.api.StatefulRedisClusterConnection;
 import io.lettuce.core.cluster.api.sync.RedisClusterCommands;
-import java.util.Collection;
-import java.util.Map;
+import io.lettuce.core.codec.StringCodec;
+import io.lettuce.core.masterreplica.MasterReplica;
+import io.lettuce.core.masterreplica.StatefulRedisMasterReplicaConnection;
+import io.netty.util.internal.StringUtil;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.kafka.common.config.ConfigException;
 import org.apache.kafka.connect.errors.ConnectException;
 import org.apache.kafka.connect.sink.SinkRecord;
 import org.apache.kafka.connect.sink.SinkTask;
 
+import java.net.URI;
+import java.util.Collection;
+import java.util.Map;
+import java.util.StringTokenizer;
+
 /**
  * Kafka Connect Task for Kafka Connect Redis Sink.
  */
 @Slf4j
 public class RedisSinkTask extends SinkTask {
+  private static final String SENTINEL_AUTH_PREFIX = "sentinelauth=";
   private static final RecordConverter RECORD_CONVERTER = new RecordConverter();
 
   private RedisClient redisStandaloneClient;
   private StatefulRedisConnection<String, String> redisStandaloneConnection;
+
+  // Add redis sentinel connection support
+  private StatefulRedisMasterReplicaConnection<String, String> redisSentinelConnection;
 
   private RedisClusterClient redisClusterClient;
   private StatefulRedisClusterConnection<String, String> redisClusterConnection;
@@ -69,11 +82,40 @@ public class RedisSinkTask extends SinkTask {
       this.writer = new Writer(redisClusterCommands);
     }
     else {
-      this.redisStandaloneClient = RedisClient.create(config.getRedisUri());
-      this.redisStandaloneConnection = this.redisStandaloneClient.connect();
+      // Add redis sentinel uri connect logic
+      // If the sentinel is configured with a password, use the "sentinelAuth" parameter in the url
+      if (config.getRedisUri().startsWith("redis-sentinel")) {
+        RedisURI redisUri = RedisURI.create(config.getRedisUri());
+        URI uri = URI.create(config.getRedisUri());
+        // Sentinel password configuration logic
+        if (!StringUtil.isNullOrEmpty(uri.getQuery())) {
+          StringTokenizer st = new StringTokenizer(uri.getQuery(), "&;");
+          // Get the sentinel-auth from url query parameters
+          while (st.hasMoreTokens()) {
+            String queryParam = st.nextToken();
+            String forStartWith = queryParam.toLowerCase();
+            if (forStartWith.startsWith(SENTINEL_AUTH_PREFIX)) {
+              final String auth = queryParam.substring(SENTINEL_AUTH_PREFIX.length());
+              if (!StringUtil.isNullOrEmpty(auth)) {
+                redisUri.getSentinels().forEach(redisSentinelUri -> redisSentinelUri.setPassword(auth.toCharArray()));
+              }
+            }
+          }
+        }
 
-      final RedisCommands<String, String> redisStandaloneCommands = this.redisStandaloneConnection.sync();
-      this.writer = new Writer(redisStandaloneCommands);
+        this.redisSentinelConnection = MasterReplica.connect(RedisClient.create(), StringCodec.UTF8, redisUri);
+        this.redisSentinelConnection.setReadFrom(ReadFrom.REPLICA_PREFERRED);
+
+        final RedisCommands<String, String> redisSentinelCommands = this.redisSentinelConnection.sync();
+        this.writer = new Writer(redisSentinelCommands);
+      }
+      else {
+        this.redisStandaloneClient = RedisClient.create(config.getRedisUri());
+        this.redisStandaloneConnection = this.redisStandaloneClient.connect();
+
+        final RedisCommands<String, String> redisStandaloneCommands = this.redisStandaloneConnection.sync();
+        this.writer = new Writer(redisStandaloneCommands);
+      }
     }
   }
 
@@ -116,6 +158,10 @@ public class RedisSinkTask extends SinkTask {
     }
     if (this.redisStandaloneClient != null) {
       this.redisStandaloneClient.shutdown();
+    }
+
+    if (this.redisSentinelConnection != null) {
+      this.redisSentinelConnection.close();
     }
 
     if (this.redisClusterConnection != null) {


### PR DESCRIPTION
The modified documents are as follows:
src/main/java/io/github/jaredpetersen/kafkaconnectredis/sink/RedisSinkTask.java == Add StatefulRedisMasterReplicaConnection for redis sentinel

docs/demo/SINK.md  == Add Sentinel configuration case